### PR TITLE
Branch a code quality

### DIFF
--- a/src/main/java/katty/KattyException.java
+++ b/src/main/java/katty/KattyException.java
@@ -73,4 +73,8 @@ public class KattyException extends Exception {
     public static KattyException badDateFormat() {
         return new KattyException("The date given is either invalid or not in a valid format as dd-MM-yyyy HH:mm.");
     }
+
+    public static KattyException invalidTimeRange() {
+        return new KattyException("Meow! Your event can't end before it starts. Are you trying to time travel?");
+    }
 }

--- a/src/main/java/katty/KattyGui.java
+++ b/src/main/java/katty/KattyGui.java
@@ -15,6 +15,13 @@ import javafx.scene.layout.VBox;
 import javafx.scene.text.Font;
 import javafx.stage.Stage;
 
+/**
+ * Provides the Graphical User Interface for the Katty application.
+ * <p>
+ * This class handles the JavaFX lifecycle, including window initialization,
+ * styling, and the message-passing loop between the user and the {@link Katty} logic.
+ * It uses a chat-style layout with distinct visual styles for user and system messages.
+ */
 public class KattyGui extends Application {
 
     private VBox chatContainer;

--- a/src/main/java/katty/task/TaskParser.java
+++ b/src/main/java/katty/task/TaskParser.java
@@ -53,8 +53,7 @@ public class TaskParser {
                 LocalDateTime end = LocalDateTime.parse(s[2], DateTimeFormatter.ofPattern(Event.EVENT_FORMAT));
 
                 if (start.isAfter(end)) {
-                    throw new KattyException("Meow! Your event can't end before it starts. "
-                            + "Are you trying to time travel?");
+                    throw KattyException.invalidTimeRange();
                 }
 
                 return new Event(s[0], s[1], s[2]);


### PR DESCRIPTION
## Description
This PR refactors exception handling for logical date errors and adds architectural documentation to the GUI layer.

## Changes
- **Exception Factory**: Added `KattyException#invalidTimeRange` to centralize the "time travel" error message.
- **GUI Documentation**: Added Javadocs to `KattyGui` to explain its role in the JavaFX lifecycle and message-passing architecture.

## Testing
1. Input: `event Physics /from 20-02-2026 18:00 /to 19-02-2026 18:00`
2. **Result**: Katty correctly catches the logic error and displays the "time travel" warning via the new exception method.

## Checklist
- [x] Hardcoded strings moved to `KattyException`
- [x] Duplicate throw statements removed from `TaskParser`
- [x] Javadocs comply with project standards